### PR TITLE
[t133024] Make formio_storage_filestore an installable module

### DIFF
--- a/formio_storage_filestore/__manifest__.py
+++ b/formio_storage_filestore/__manifest__.py
@@ -16,7 +16,7 @@
         'data/ir_cron_data.xml'
     ],
     'application': True,
-    'installable': False,
+    'installable': True,
     'images': [
         'static/description/banner.gif',
     ],


### PR DESCRIPTION


<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://www.braintec.com/web#view_type=form&model=project.task&id=133024">[t133024] t1007 EiV-Formular via formio / Build form for EIV with formio</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>formio_storage_filestore</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->